### PR TITLE
Some fixes and optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ neat_html:
   exclude:
 ```
 - **enable** - Enable the plugin. Defaults to `true`.
+- **logger** - Print log switch. Defaults to `true`.
 - **exclude**: Exclude files
 **Note:** there are so many params please see '[HTMLMinifier](https://github.com/kangax/html-minifier)'
 ----------
@@ -37,6 +38,7 @@ neat_css:
     - '*.min.css'
 ```
 - **enable** - Enable the plugin. Defaults to `true`.
+- **logger** - Print log switch. Defaults to `true`.
 - **exclude**: Exclude files
 
 ----------
@@ -52,6 +54,7 @@ neat_js:
 ```
 - **enable** - Enable the plugin. Defaults to `true`.
 - **mangle**: Mangle file names
+- **logger** - Print log switch. Defaults to `true`.
 - **output**: Output options
 - **compress**: Compress options
 - **exclude**: Exclude files

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var assign = require('object-assign');
         // HTML minifier
         hexo.config.neat_html = assign({
             enable: true,
+            logger: true,
             exclude: [],
             ignoreCustomComments: [/^\s*more/],
             removeComments: true,
@@ -20,6 +21,7 @@ var assign = require('object-assign');
         // Css minifier
         hexo.config.neat_css = assign({
             enable: true,
+            logger: true,
             exclude: ['*.min.css']
         }, hexo.config.neat_css);
 
@@ -27,6 +29,7 @@ var assign = require('object-assign');
         hexo.config.neat_js = assign({
             enable: true,
             mangle: true,
+            logger: true,
             output: {},
             compress: {},
             exclude: ['*.min.js']

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -24,10 +24,12 @@ function logic_html(str, data) {
         }
     }
 
-    var log = hexo.log || console.log;
     var result = Htmlminifier(str, options);
     var saved = ((str.length - result.length) / str.length * 100).toFixed(2);
-    log.log('neat the html: %s [ %s saved]', path, saved + '%');
+    if (options.logger) {
+        var log = hexo.log || console.log;
+        log.log('neat the html: %s [ %s saved]', path, saved + '%');
+    }
     var prefix = '<!-- build time:' + Date() + " -->";
     var end = '<!-- rebuild by neat -->';
     result = prefix + result + end;
@@ -50,16 +52,18 @@ function logic_css(str, data) {
         }
     }
 
-    var log = hexo.log || console.log;
-    return new Promise(function(resolve, reject) {
-        new CleanCSS(options).minify(str, function(err, result) {
+    return new Promise(function (resolve, reject) {
+        new CleanCSS(options).minify(str, function (err, result) {
             if (err) return reject(err);
             var saved = ((str.length - result.styles.length) / str.length * 100).toFixed(2);
             var prefix = '/* build time:' + Date().toLocaleString() + "*/\n";
             var end = '\n/* rebuild by neat */';
             var css_result = prefix + result.styles + end;
             resolve(css_result);
-            log.log('neat the css: %s [ %s saved]', path, saved + '%');
+            if (options.logger) {
+                var log = hexo.log || console.log;
+                log.log('neat the css: %s [ %s saved]', path, saved + '%');
+            }
         });
     });
 }
@@ -80,17 +84,17 @@ function logic_js(str, data) {
         }
     }
 
-    var log = hexo.log || console;
     var result = UglifyJS.minify(str, options);
     var saved = ((str.length - result.code.length) / str.length * 100).toFixed(2);
-    log.log('neat the js: %s [ %s saved]', path, saved + '%');
+    if (options.logger) {
+        var log = hexo.log || console.log;
+        log.log('neat the js: %s [ %s saved]', path, saved + '%');
+    }
     var prefix = '// build time:' + Date().toLocaleString() + "\n";
     var end = '\n//rebuild by neat ';
     var js_result = prefix + result.code + end;
     return js_result;
 }
-
-
 
 module.exports = {
     logic_html: logic_html,

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -20,7 +20,7 @@ function logic_html(str, data) {
 
     if (path && exclude && exclude.length) {
         for (var i = 0, len = exclude.length; i < len; i++) {
-            if (minimatch(path, exclude[i])) return str;
+            if (minimatch(path, exclude[i], {matchBase: true})) return str;
         }
     }
 
@@ -46,7 +46,7 @@ function logic_css(str, data) {
 
     if (path && exclude && exclude.length) {
         for (var i = 0, len = exclude.length; i < len; i++) {
-            if (minimatch(path, exclude[i])) return str;
+            if (minimatch(path, exclude[i], {matchBase: true})) return str;
         }
     }
 
@@ -76,7 +76,7 @@ function logic_js(str, data) {
 
     if (path && exclude && exclude.length) {
         for (var i = 0, len = exclude.length; i < len; i++) {
-            if (minimatch(path, exclude[i])) return str;
+            if (minimatch(path, exclude[i], {matchBase: true})) return str;
         }
     }
 


### PR DESCRIPTION
> 1. I found that `exclude` configuration didn't work, so I fixed it.

> 2. When a computer is not performing well, printing logs can lead to poor compilation performance. So I added a switch configuration for printing logs (the default is on, so it is compatible). I've updated `README. md`, the configuration now looks like this:

```
neat_enable: true

neat_html:
  enable: true
  logger: false
  exclude:

neat_css:
  enable: true
  logger: false
  exclude:
    - '*.min.css'

neat_js:
  enable: true
  mangle: true
  logger: false
  output:
  compress:
  exclude:
    - '*.min.js'
```