### PR TITLE
Update clean-css to fix ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "bluebird": "^3.3.5",
-    "clean-css": ">2.0.0",
-    "html-minifier": "^2.1.2",
+    "clean-css": "~4.1.11",
+    "html-minifier": "~3.5.0",
     "minimatch": "^3.0.0",
     "object-assign": "^4.1.0",
     "stream-to-array": "^2.3.0",


### PR DESCRIPTION
This also update html-minifier which depends on clean-css
More info:
https://snyk.io/test/npm/hexo-neat
https://snyk.io/vuln/npm:clean-css:20180306