### PR TITLE
fix #26 (ES5): 当调用UglifyJS.minify时，只把uglify-js需要的参数传进去，避免传入无用参数引起uglify-js报错。

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -81,7 +81,14 @@ function logic_js(str, data) {
         }
     }
 
-    var result = UglifyJS.minify(str, options);
+    var uglify_v3_allow_options = ["parse", "compress", "mangle", "output", "sourceMap", "nameCache", "toplevel", "warnings"]
+    var uglify_options = {}
+    for (var j = 0; j < uglify_v3_allow_options; j++) {
+        var key = uglify_v3_allow_options[j];
+        if (options[key] !== undefined) uglify_options[key] = options[key]
+    }
+
+    var result = UglifyJS.minify(str, uglify_options);
     if (!result.error) {
         var saved = (((str.length - result.code.length) / str.length) * 100).toFixed(2);
         if (options.logger) {
@@ -91,7 +98,7 @@ function logic_js(str, data) {
         var prefix = '// build time:' + Date().toLocaleString() + '\n';
         var end = '\n//rebuild by neat ';
         js_result = prefix + result.code + end;
-    }
+    } else throw result.error;
     return js_result;
 }
 


### PR DESCRIPTION
您好，由于观察到您到目前为止的代码仍然保持着ES5的标准，因此这个PR中的fix版本仍然使用ES5语法，从而可以继续兼容老版本的Node。

#28 则是使用ES6语法的fix版本，同时也移除了无用依赖、升级了需要的依赖到最新。您可以根据情况选择Merge哪一个。

非常感谢！

Fix #26 .