### PR TITLE
fix #26 (ES6): 当调用UglifyJS.minify时，只把uglify-js需要的参数传进去，避免传入无用参数引起uglify-js报错。

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 /* global hexo */
-var assign = require('object-assign');
 
 //module.exports = function (hexo) {
     if (true === hexo.config.neat_enable) {
         // HTML minifier
-        hexo.config.neat_html = assign({
+        hexo.config.neat_html = Object.assign({
             enable: true,
             logger: true,
             exclude: [],
@@ -19,23 +18,22 @@ var assign = require('object-assign');
         }, hexo.config.neat_html);
 
         // Css minifier
-        hexo.config.neat_css = assign({
+        hexo.config.neat_css = Object.assign({
             enable: true,
             logger: true,
             exclude: ['*.min.css']
         }, hexo.config.neat_css);
 
         // Js minifier
-        hexo.config.neat_js = assign({
+        hexo.config.neat_js = Object.assign({
             enable: true,
             mangle: true,
             logger: true,
             output: {},
             compress: {},
-            exclude: ['*.min.js']
-        }, hexo.config.neat_js, {
-                fromString: true
-            });
+            exclude: ['*.min.js'],
+            warnings: true
+        }, hexo.config.neat_js);
 
 
         var filter = require('./lib/filter');

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -2,9 +2,7 @@
 'use strict';
 var CleanCSS = require('clean-css'),
     UglifyJS = require('uglify-js'),
-    Htmlminifier = require('html-minifier').minify,
-    streamToArray = require('stream-to-array');
-var Promise = require('bluebird');
+    Htmlminifier = require('html-minifier').minify;
 var minimatch = require('minimatch');
 
 function logic_html(str, data) {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -81,7 +81,13 @@ function logic_js(str, data) {
         }
     }
 
-    var result = UglifyJS.minify(str, options);
+    const uglify_v3_allow_options = ["parse", "compress", "mangle", "output", "sourceMap", "nameCache", "toplevel", "warnings"]
+    const uglify_options = {}
+    for (let key of uglify_v3_allow_options) {
+        if (options[key] !== undefined) uglify_options[key] = options[key]
+    }
+
+    var result = UglifyJS.minify(str, uglify_options);
     if (!result.error) {
         var saved = (((str.length - result.code.length) / str.length) * 100).toFixed(2);
         if (options.logger) {
@@ -91,7 +97,7 @@ function logic_js(str, data) {
         var prefix = '// build time:' + Date().toLocaleString() + '\n';
         var end = '\n//rebuild by neat ';
         js_result = prefix + result.code + end;
-    }
+    } else throw result.error;
     return js_result;
 }
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,10 @@
     "url": "git@github.com:rozbo/hexo-neat.git"
   },
   "dependencies": {
-    "bluebird": "^3.7.2",
-    "clean-css": "^4.2.3",
+    "clean-css": "^5.2.4",
     "html-minifier": "^4.0.0",
-    "minimatch": "^3.0.4",
-    "object-assign": "^4.1.1",
-    "stream-to-array": "^2.3.0",
-    "uglify-js": "~3.10.0"
+    "minimatch": "^5.0.1",
+    "uglify-js": "^3.15.2"
   },
   "description": "auto Minify html、js、css and make it neat",
   "devDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,28 +2,17 @@
 # yarn lockfile v1
 
 
-any-promise@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-bluebird@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
   dependencies:
     balanced-match "^1.0.0"
-    concat-map "0.0.1"
 
 camel-case@^3.0.0:
   version "3.0.0"
@@ -33,10 +22,17 @@ camel-case@^3.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
-clean-css@>4.2.3, clean-css@^4.2.1:
+clean-css@^4.2.1:
   version "4.2.3"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
+  dependencies:
+    source-map "~0.6.0"
+
+clean-css@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.npmmirror.com/clean-css/-/clean-css-5.2.4.tgz#982b058f8581adb2ae062520808fb2429bd487a4"
+  integrity sha512-nKseG8wCzEuji/4yrgM/5cthL9oTDc5UOQyFMvW/Q53oP6gLH690o1NbuTh6Y18nujr7BxlsFuS7gXLnLzKJGg==
   dependencies:
     source-map "~0.6.0"
 
@@ -44,11 +40,6 @@ commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 he@^1.2.0:
   version "1.2.0"
@@ -73,12 +64,12 @@ lower-case@^1.1.1:
   resolved "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
-minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+minimatch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmmirror.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
   dependencies:
-    brace-expansion "^1.1.7"
+    brace-expansion "^2.0.1"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -86,11 +77,6 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
-
-object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 param-case@^2.1.1:
   version "2.1.1"
@@ -109,14 +95,12 @@ source-map@~0.6.0:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-stream-to-array@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz#bbf6b39f5f43ec30bc71babcb37557acecf34353"
-  integrity sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=
-  dependencies:
-    any-promise "^1.1.0"
+uglify-js@^3.15.2:
+  version "3.15.2"
+  resolved "https://registry.npmmirror.com/uglify-js/-/uglify-js-3.15.2.tgz#1ed2c976f448063b1f87adb68c741be79959f951"
+  integrity sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==
 
-uglify-js@^3.5.1, uglify-js@~3.10.0:
+uglify-js@^3.5.1:
   version "3.10.0"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz#397a7e6e31ce820bfd1cb55b804ee140c587a9e7"
   integrity sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==


### PR DESCRIPTION
您好，这一版本是使用ES6语法的fix版本，同时也移除了无用依赖、升级了需要的依赖到最新。

#27 提供了使用ES5语法的fix，您可以根据情况选择Merge哪一个。

非常感谢！

Fix #26 .